### PR TITLE
Exclude software rasterization tests from github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Test
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: ctest -C $BUILD_TYPE
+      run: ctest -C $BUILD_TYPE --exclude-regex '.*SWRAST'
 
     - name: Run clang-tidy
       shell: bash


### PR DESCRIPTION
They can't run there because we don't have a software
rasterizer (and it would cost a lot of bandwidth and time to
install it for each build job)

