### PR TITLE
Fix release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       if: ${{ matrix.os == 'windows-latest' }}
 
     - name: Publish release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v0.1.13
       with:
         files: |
           ${{runner.workspace}}/build/RamsesLogic-*.deb


### PR DESCRIPTION
It was a rookie mistake to not pin the version of the jobs we use. It turned out they updated some
glob dependency and broke our release jobs, because now the backslashes are not matched
properly on Windows hosts.

More info here:
https://github.com/softprops/action-gh-release/issues/280 